### PR TITLE
Added support for containered scroll div

### DIFF
--- a/src/masonry-wall.vue
+++ b/src/masonry-wall.vue
@@ -47,6 +47,7 @@ const props = withDefaults(
     gap?: number
     rtl?: boolean
     ssrColumns?: number
+    scrollTarget?: HTMLElement
   }>(),
   {
     columnWidth: 400,
@@ -56,7 +57,7 @@ const props = withDefaults(
   }
 )
 
-const { columnWidth, items, gap, rtl, ssrColumns } = toRefs(props)
+const { columnWidth, items, gap, rtl, ssrColumns, scrollTarget } = toRefs(props)
 const columns = ref<Column[]>([])
 const wall = ref<HTMLDivElement>() as Ref<HTMLDivElement>
 
@@ -109,9 +110,9 @@ async function redraw(force = false) {
     return
   }
   columns.value = createColumns(columnCount())
-  const scrollY = window.scrollY
+  const scrollY = scrollTarget?.value?.scrollTop ?? window.scrollY
   await fillColumns(0)
-  window.scrollTo({ top: scrollY })
+  (scrollTarget?.value ?? window).scrollTo({ top: scrollY })
   emit('redraw')
 }
 


### PR DESCRIPTION
# Description

Issue #15 described a bug where the view would be scrolled to the top whenever new data was added.
This was fixed by saving the `window.scrollY` position, but this does not work if the view scrolls separate from the window.

This PR adds a new optional prop, which accepts a ref to the scrolling container. If the prop is not given, `window` is used as before. This fixes the scrolling bug for containerized views.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update
- [ ] Documentation only

# Checklist:

- [x] My code follows the style and commit guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
